### PR TITLE
NOISSUE: Fix link for Rod Johnson's Spring AI talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 - [Building Agents with AWS: Complete Tutorial • Josh Long & James Ward](https://www.youtube.com/watch?v=Y291afdLroQ) - November 2024
 - [Supercharging your AI Applications with Spring AI Advisors • Spring Team](https://spring.io/blog/2024/10/02/supercharging-your-ai-applications-with-spring-ai-advisors) - October 2024
 - [Spring AI Is All You Need • Christian Tzolov • GOTO Amsterdam 2024](https://www.youtube.com/watch?v=vuhMti8B5H0) - June 2024
-- [Practical GenAI with Spring AI • Rod Johnson @ YOW! 2024](https://www.youtube.com/watch?v=4oaK3rKHiqs) - June 2024
+- [Practical GenAI with Spring AI • Rod Johnson @ YOW! 2024](https://www.youtube.com/watch?v=J5xglswsXdg) - June 2024
 - [Introducing Spring AI by Christian Tzolov / Mark Pollack @ Spring I/O 2024](https://www.youtube.com/watch?v=umKbaXsiCOY) - May 2024
 - [Bringing GenAI to the Modern Enterprise. A production use-case. In Serverless Java !! • Dan Dobrin • Devoxx Belgium 2024](https://devoxx.be/talk/?id=8188) - May 2024
 - [Bootiful Spring Boot • Josh Long @ SpringOne 2024](https://www.youtube.com/watch?v=ex7rnzIMmlk) - January 2024


### PR DESCRIPTION
The current link is not valid & ends up with below error
<img width="655" height="475" alt="image" src="https://github.com/user-attachments/assets/b9bcb6b7-a361-4512-9c40-d10747d85f6a" />

Fixing the link for `Practical GenAI with Spring AI • Rod Johnson @ YOW! 2024` 