### PR TITLE
Add JamJet — durable execution starter for Spring AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 
 ### Extensions and Forks
 
+- [JamJet Spring Boot Starter](https://github.com/jamjet-labs/jamjet-spring) - Adds durable execution to Spring AI agents with zero code changes. One dependency gives your ChatClient crash recovery (resume from last checkpoint), event-sourced audit trails, human-in-the-loop approval, Micrometer metrics, and OpenTelemetry tracing. Includes a JUnit 5 replay testing framework for deterministic agent tests. Powered by the [JamJet runtime](https://github.com/jamjet-labs/jamjet) (Rust/Tokio). Also supports LangChain4j via `langchain4j-jamjet`. Published on [Maven Central](https://central.sonatype.com/artifact/dev.jamjet/jamjet-spring-boot-starter).
 - [Spring AI Alibaba](https://github.com/alibaba/spring-ai-alibaba) - An extension of Spring AI that provides an agentic AI framework for Java developers. Adds support for Alibaba Cloud QWen models and Dashscope services, along with additional features like conversation memory, RAG support, and function calling. Maintains compatibility with the Spring AI API while offering specialized capabilities for Alibaba Cloud's AI ecosystem.
 
 ### Development Tools


### PR DESCRIPTION
## What

Adds [JamJet Spring Boot Starter](https://github.com/jamjet-labs/jamjet-spring) to the Extensions and Forks section.

## Why

JamJet fills a gap in the Spring AI ecosystem: **production durability infrastructure**. Existing extensions cover model providers and orchestration — JamJet provides the durable execution layer underneath.

Add one dependency, and every ChatClient.call() gains:
- **Crash recovery** — resume from last checkpoint if the process crashes
- **Event-sourced audit trails** — compliance-ready logging of prompts, responses, tool calls
- **Human-in-the-loop** — pause/resume for approval workflows
- **Micrometer + OpenTelemetry** — production observability
- **JUnit 5 replay testing** — deterministic agent tests with recorded executions

Works via Spring AI BaseAdvisor pattern — zero code changes to existing ChatClient usage.

**Published on Maven Central:** dev.jamjet:jamjet-spring-boot-starter:0.1.0

- [GitHub](https://github.com/jamjet-labs/jamjet-spring)
- [Docs](https://docs.jamjet.dev)
- [Maven Central](https://central.sonatype.com/artifact/dev.jamjet/jamjet-spring-boot-starter)
