### PR TITLE
docs: add MateClaw to UI Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 
 - [Spring AI Playground](https://github.com/JM-Lab/spring-ai-playground) - A web UI designed to make it easy for Java developers to experiment with and integrate AI models. Provides an interactive interface for testing different prompts and models.
 
+- [MateClaw](https://github.com/matevip/mateclaw) - An open-source personal AI operating system on Spring Boot 3.5 + Spring AI Alibaba. One JAR ships a web admin console, a desktop app (bundled JRE 21), an embeddable widget, a Java plugin SDK, and 8 IM channels — DingTalk, Feishu, WeChat Work, WeChat, Telegram, Discord, QQ, Slack — all sharing the same agent runtime. Includes ReAct + Plan-and-Execute agents on Spring AI Alibaba's StateGraph, multi-vendor failover with health tracking, an LLM Wiki with per-sentence citations, memory lifecycle, MCP, and a Tool Guard approval layer.
+
 ### CLI Applications
 
 - [Spring AI Chat Bot CLI](https://github.com/tzolov/spring-ai-cli-chatbot) - Command-line chatbot with Retrieval-Augmented Generation (RAG) and conversational memory capabilities. Demonstrates how to build interactive CLI applications with Spring AI.


### PR DESCRIPTION
## Summary

Adds **MateClaw** to the **Code & Examples → UI Clients** section. MateClaw is an open-source personal AI operating system built on Spring Boot 3.5 + Spring AI Alibaba — a natural fit alongside the existing Spring AI Alibaba entry under Extensions and Forks.

## Why it fits this list

- **Spring Boot 3.5 + Spring AI Alibaba 1.1** in production — uses Spring AI's chat client / function calling / advisors, MyBatis Plus for ORM, Flyway for migrations.
- Built on Spring AI Alibaba's **StateGraph** runtime — ReAct + Plan-and-Execute agents implemented as nodes/edges, not just framework-on-top.
- Demonstrates production-shape patterns Spring AI users care about: multi-vendor failover with health tracking, MCP servers (stdio / SSE / Streamable HTTP), tool approval flow, audit log, JWT auth, RBAC.
- Ships as **one JAR** — the Vue 3 admin SPA is built into the backend's `static/` so a single Spring Boot process serves everything.

## What was added

One bullet appended to the end of `### UI Clients` in `README.md`. No reordering.

## Links

- Repo: https://github.com/matevip/mateclaw
- Documentation: https://claw.mate.vip/docs
- Live demo: https://claw-demo.mate.vip
- Apache 2.0