### PR TITLE
Add Cycles Spring AI Starter to Extensions and Forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 ### Extensions and Forks
 
 - [Spring AI Alibaba](https://github.com/alibaba/spring-ai-alibaba) - An extension of Spring AI that provides an agentic AI framework for Java developers. Adds support for Alibaba Cloud QWen models and Dashscope services, along with additional features like conversation memory, RAG support, and function calling. Maintains compatibility with the Spring AI API while offering specialized capabilities for Alibaba Cloud's AI ecosystem.
+- [Cycles Spring AI Starter](https://github.com/runcycles/cycles-spring-ai-starter) - A Spring AI advisor + auto-configuration that adds budget enforcement and runtime authority to `ChatClient` invocations. Performs a reserve → call → commit/release lifecycle against the [Cycles](https://runcycles.io) authority server before each LLM call; denials throw before contacting the provider. Multi-tenant LLM cost control with per-subject attribution. Compatible with Java 21+, Spring Boot 3.5+, and Spring AI 1.0+.
 
 ### Development Tools
 


### PR DESCRIPTION
Adds [`cycles-spring-ai-starter`](https://github.com/runcycles/cycles-spring-ai-starter) under the `Extensions and Forks` section.

## What it is

A Spring AI advisor + auto-configuration that adds budget enforcement and runtime authority to `ChatClient` invocations. The advisor performs a **reserve → call → commit/release** lifecycle against the [Cycles](https://runcycles.io) authority server before each LLM call:

- **Pre-call**: reserves the estimated budget. If the budget is exhausted, throws `CyclesBudgetDeniedException` *before* contacting the LLM provider.
- **Post-call (success)**: commits the actual usage back to Cycles.
- **Post-call (exception)**: releases the reservation.

Wired automatically via Spring AI's `ChatClientCustomizer` mechanism — no code changes at call sites.

## Why it might belong here

- Multi-tenant LLM cost control with per-subject attribution (tenant/workspace/app/agent dimensions).
- Action-authority gates: deny LLM calls *before* the provider is hit, rather than observing after.
- Companion to the more general [`cycles-spring-boot-starter`](https://github.com/runcycles/cycles-spring-boot-starter) (which uses an `@Cycles` AOP annotation for non-Spring-AI code paths).

## Compatibility

- Java 21+
- Spring Boot 3.5+
- Spring AI 1.0+ (verified compatible with 1.1.x)

## v0.1.0

First public release published to Maven Central today (2026-05-12):

```xml
<dependency>
    <groupId>io.runcycles</groupId>
    <artifactId>cycles-spring-ai-starter</artifactId>
    <version>0.1.0</version>
</dependency>
```

100% test coverage, Apache 2.0. Repository: <https://github.com/runcycles/cycles-spring-ai-starter>.