### PR TITLE
Add Regulus to Extensions and Forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 ### Extensions and Forks
 
 - [Spring AI Alibaba](https://github.com/alibaba/spring-ai-alibaba) - An extension of Spring AI that provides an agentic AI framework for Java developers. Adds support for Alibaba Cloud QWen models and Dashscope services, along with additional features like conversation memory, RAG support, and function calling. Maintains compatibility with the Spring AI API while offering specialized capabilities for Alibaba Cloud's AI ecosystem.
+- [Regulus](https://github.com/neul-labs/regulus) - Open-source EU & UK compliance plane for Google ADK. Runtime ADK plugin suite with PII redaction, dual-control kill switch, fail-closed data residency, model-risk tiering, and hash-chained audit envelopes mapped to EU AI Act, GDPR, DORA, NIS2, UK GDPR, FCA SYSC, PRA SS1/23. Spring Boot starter auto-wires every plugin from `application.yaml`. (MIT, Maven `com.neullabs:regulus-ai-adk-plugins`, ADK 1.2.0)
 
 ### Development Tools
 


### PR DESCRIPTION
Adds [Regulus](https://github.com/neul-labs/regulus) — the EU & UK compliance plane for Google ADK — to the **Extensions and Forks** section.

Regulus is a Java 21, MIT-licensed runtime ADK `BasePlugin` suite that encodes 10 regulations (EU AI Act, GDPR, DORA, NIS2, EHDS, UK GDPR, FCA SYSC, PRA SS1/23, PRA SS2/21, NHS DSPT) as composable profiles. Ships a Spring Boot starter that auto-wires every plugin from `application.yaml`. Hash-chained audit envelopes + GRC adapters (ServiceNow IRM, OneTrust AI Governance, MetricStream, signed webhooks).

Fits as a Java AI engineering framework extension in the same family as Spring AI Alibaba.