### PR TITLE
Add Dokimos to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 
 - [Arconia Ollama Dev Service](https://arconia.io/docs/arconia/latest/dev-services/ollama/) - A Spring Boot development service that automatically manages Ollama instances for local LLM development. Simplifies testing and development with local models by handling container lifecycle and configuration. Integrates seamlessly with Spring AI's Ollama support.
 - [json-io](https://github.com/jdereg/json-io) — Java library with full TOON read/write support for LLM-optimized serialization. Achieves 40-50% token reduction vs JSON while handling complex object graphs, cyclic references, and generics.
+- [Dokimos](https://github.com/dokimos-dev/dokimos) - An LLM and AI-agent evaluation framework for Java and Kotlin. Its `dokimos-spring-ai` module uses Spring AI's `ChatClient` and `ChatModel` as evaluation judges, and it can score LLM responses, tool calls, and agent execution traces as part of a JUnit test suite or CI pipeline. (MIT, Maven Central `dev.dokimos`)
 
 ### Model Context Protocol
 


### PR DESCRIPTION
Adds Dokimos to Development Tools.

Dokimos is an LLM and AI-agent evaluation framework for Java and Kotlin. Its dokimos-spring-ai module turns a Spring AI ChatClient or ChatModel into an evaluation judge. It scores LLM responses, tool calls, and agent traces inside a JUnit test or a CI pipeline.

Disclosure: I maintain Dokimos. It is MIT licensed and published to Maven Central under dev.dokimos.
