### PR TITLE
Add Spring AI Business Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 
 - [Spring AI Showcase by Piotr Minkowski](https://github.com/piomin/spring-ai-showcase) - Modular demo project showcasing multiple Spring AI features including prompt templates, chat memory, structured output, function calling, RAG with Pinecone vector store, and image models. Supports multiple AI providers (OpenAI, Mistral, Ollama, Azure OpenAI) with profile-based configuration.
 
+- [Spring AI Business Copilot](https://github.com/qcodingdev/spring-ai-business-copilot) - Production-style, runnable business workflows for Text-to-SQL, cited RAG, customer support, grounded reports, and evidence-based resume review, with deterministic guardrails, human confirmation, audit trails, PostgreSQL/pgvector, and Docker Compose.
+
 ### Code Examples
 
 - [Spring AI Official Examples](https://github.com/spring-projects/spring-ai-examples) - Comprehensive official repository containing examples for all Spring AI features including MCP dynamic tools, prompt engineering patterns, agentic workflows, vector stores, and various model integrations (2025)


### PR DESCRIPTION
## What this adds

Adds [Spring AI Business Copilot](https://github.com/qcodingdev/spring-ai-business-copilot) to the Comprehensive Example Collections section.

## Why it belongs

- Five runnable Spring AI business workflows: Text-to-SQL, cited RAG, customer support, grounded reports, and evidence-based resume review
- Production-style boundaries including deterministic guardrails, evidence IDs, human confirmation, lifecycle state, and audit trails
- Java 21, Spring Boot 4.1, Spring AI 2.0, PostgreSQL/pgvector, and Docker Compose
- Public MIT-licensed repository with a bilingual README, v2.0.0 release, real workbench screenshots, and fictional sample data

## Validation

- Verified the repository URL is publicly accessible
- Kept the change to one entry in the existing Comprehensive Example Collections section
- Ran `git diff --check`
