### PR TITLE
Add Live Tennis API MCP Server (Domain-Specific MCP Implementations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 - [GitHub MCP Application](https://x.com/Stephan007/status/1910640447740838356) - A 100% Java GitHub MCP application built on Spring AI by Stephan Janssen, creator of Devoxx.
 - [Druid MCP Server](https://github.com/iunera/druid-mcp-server) - A Java-based Enterprise MCP server for Apache Druid that provides extensive tools, resources, and AI-assisted prompts for managing and analyzing Druid clusters using spring-ai-1.1.0 Milestone with the new @Mcp Annotations (@McpTool) and Oauth
 - [AWS Sample MCP Demos](https://github.com/aws-samples/Sample-Model-Context-Protocol-Demos) - Collection of examples showing how to use Model Context Protocol with AWS services, including Spring AI implementations.
+- [Live Tennis API MCP Server](https://github.com/livetennisapi/livetennisapi-mcp) - Official MCP server for the Live Tennis API providing real-time tennis scores, players, fixtures, results and odds across ATP, WTA, Challenger and ITF. Consumable from Spring AI's MCP client support via stdio (`npx -y livetennisapi-mcp`) or a hosted Streamable HTTP endpoint (`https://mcp.livetennisapi.com/mcp`, API-key auth); free tier available.
 
 ## Community
 


### PR DESCRIPTION
Adds the **Live Tennis API MCP Server** to *Model Context Protocol → Domain-Specific MCP Implementations* (one line, matching the existing entry style).

- Official first-party MCP server from [Live Tennis API](https://livetennisapi.com): real-time tennis scores, players, fixtures, results and odds (ATP, WTA, Challenger, ITF).
- Usable from Spring AI's MCP client support either over stdio (`npx -y livetennisapi-mcp`) or via its hosted Streamable HTTP endpoint `https://mcp.livetennisapi.com/mcp` (endpoint verified live — MCP `initialize` responds). Auth is an API key sent as a bearer token; free tier (1,000 req/day, no card) at https://livetennisapi.com/subscribe/free.
- Source: https://github.com/livetennisapi/livetennisapi-mcp (MIT) · npm: `livetennisapi-mcp` · docs: https://docs.livetennisapi.com

Disclosure: this is a vendor/first-party submission (we maintain the server). Happy to move the entry or trim the description if you prefer a different section.