### PR TITLE
Add Spring AI ERP Assistant to Code Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 - [Spring AI with QianFan](https://gitee.com/dino9527/spring-ai-examples.git) - Spring AI support for various AI language models from QianFan. Shows how to interact with QianFan language models and create a multilingual conversational assistant based on QianFan models.
 - [Similarity Search using Spring AI](https://github.com/thecodemonkey/SimilaritySearch) - Implementation of a simple similarity search. Demonstrating how to use Kotlin or Java with Spring-AI to generate embeddings and perform simple similarity searches (March 2025)
 - [Spring AI Shopping Agent with Short-Term & Long-Term Memory](https://github.com/dominikcebula/spring-ai-shopping-agent) - AI-powered shopping assistant built with Spring AI and the Model Context Protocol (MCP).
+- [Spring AI ERP Assistant](https://github.com/ly1836/spring-ai-rag-demo) - Full-stack manufacturing ERP assistant built with Spring AI 2.0 and Spring Boot 4, featuring RAG, 39 tools across eight ERP modules, runtime-managed read-only SQL tools, multi-tenant isolation, JDBC chat memory, Tool tracing, billing, and 23 trusted ECharts visualizations.
 
 ### UI Clients
 


### PR DESCRIPTION
## What this adds

Adds [Spring AI ERP Assistant](https://github.com/ly1836/spring-ai-rag-demo) to the Code Examples section.

## Why it belongs

- Runnable, full-stack manufacturing ERP assistant built with Spring AI 2.0 and Spring Boot 4
- Combines RAG with 39 business Tools across eight ERP modules
- Supports runtime-managed read-only SQL Tools with tenant isolation
- Includes JDBC chat memory, Tool tracing, billing, and SSE streaming
- Generates 23 trusted ECharts visualizations from structured Tool results
- Supports DeepSeek, Qwen, and Google Gemini
- Provides Docker Compose deployment, a bilingual README, an animated demo, and an Apache-2.0 license
- Latest public release: [3.0.4](https://github.com/ly1836/spring-ai-rag-demo/releases/tag/3.0.4)

## Validation

- Verified that the repository is publicly accessible
- Verified that the English README includes setup and architecture information
- Kept the change limited to one entry in the existing Code Examples section
- No code changes or tests are required for this documentation-only update