### PR TITLE
Add Agent QA to development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 
 ### Development Tools
 
+- [Agent QA](https://github.com/vostride/agent-qa) - Source-available QA agent for natural-language web and mobile regression tests around deployed Spring AI applications. It provides a CLI, dashboard, MCP server, persistent test memory, and local or OpenAI-compatible model support.
 - [Arconia Ollama Dev Service](https://arconia.io/docs/arconia/latest/dev-services/ollama/) - A Spring Boot development service that automatically manages Ollama instances for local LLM development. Simplifies testing and development with local models by handling container lifecycle and configuration. Integrates seamlessly with Spring AI's Ollama support.
 - [json-io](https://github.com/jdereg/json-io) — Java library with full TOON read/write support for LLM-optimized serialization. Achieves 40-50% token reduction vs JSON while handling complex object graphs, cyclic references, and generics.
 


### PR DESCRIPTION
## Summary

- add Agent QA under Development Tools
- describe its natural-language web/mobile regression testing, CLI, dashboard, MCP server, persistent test memory, and model compatibility
- scope it explicitly to black-box testing around deployed Spring AI applications

## Why it fits

[Agent QA](https://github.com/vostride/agent-qa) is a source-available, self-improving QA agent for software teams. It can exercise the user-facing web or mobile behavior around a Spring AI application without claiming a native Spring AI integration.

The current license is FSL-1.1-ALv2 and converts to Apache-2.0 after two years. I am affiliated with the project.

## Validation

- `git diff --check` passes.
- The project URL is unique in the README.
- The new item uses the section's existing list format and ends with punctuation.
- Standard `awesome-lint` reports the repository's existing baseline of 115 errors and two warnings; the added line appears in none of its diagnostics.
