### PR TITLE
docs: add webforJ MCP Apps to UI Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Spring AI is a project from the Spring team that provides a familiar and consist
 
 ### UI Clients
 
+- [webforJ MCP Apps](https://docs.webforj.com/docs/integrations/mcp-apps/overview) - Publishes routed webforJ views as interactive MCP Apps on a Spring AI MCP server. An MCP host opens the live view inside its conversation, and the view stays part of the running Java app with its components, services, routing, and state, so the whole application including the UI is written in Java.
 - [Spring AI HTMX MCP](https://github.com/habuma/spring-ai-examples/tree/main/spring-ai-htmx-mcp) - Example of building a modern, interactive UI for Spring AI applications using HTMX. Demonstrates how to create a responsive chat interface with minimal JavaScript by leveraging HTMX's server-side rendering capabilities combined with Spring AI's Model Context Protocol.
 
 - [Spring AI Vaadin](https://github.com/spring-ai-community/spring-ai-vaadin) - Integration of Spring AI with Vaadin, a Java web framework for building modern web applications. Provides components and examples for creating rich, interactive AI-powered UIs with pure Java, without requiring JavaScript or HTML knowledge.


### PR DESCRIPTION
Adds [webforJ MCP Apps](https://docs.webforj.com/docs/integrations/mcp-apps/overview) to the UI Clients section.

webforJ is a Java web framework. Its MCP Apps integration builds on spring-ai-starter-mcp-server-webmvc: annotating a routed view publishes a tool and a UI resource on the Spring AI MCP server, and an MCP Apps capable host opens the live view inside its conversation. The view remains part of the running Java app with its components, services, routing, and state, so the entire application including the UI layer is written in Java.


https://github.com/user-attachments/assets/fcd68414-887e-4d41-8995-9f9060760c30

